### PR TITLE
Make commands copyable via Github's code block copy button.

### DIFF
--- a/__tests__/fixtures/pull_request/github/comment_create_body_expected.js
+++ b/__tests__/fixtures/pull_request/github/comment_create_body_expected.js
@@ -6,11 +6,74 @@ module.exports = {
 
 By commenting on this PR with: \`:rocket:[<pipeline>]\`, e.g.
 
-| Comment | Description | More info |
-| --- | --- | --- |
-| \`:rocket:[a-pipeline]\` |  | [:information_source:](https://example.com/does-templating-work?COMMITISH=c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffe&ORG=some-org&REPO=some-repo "See more information") |
-| \`:rocket:[some-pipeline]\` |  | [:heavy_plus_sign:](https://github.com/some-org/some-repo/new/master?filename=.buildkite%2Fpipeline%2Fdescription%2Fsome-org%2Fsome-pipeline.md&value=%23+some-pipeline%0A%0A%5BDocument+some-pipeline%27s+RocketBot+options+here%5D "Add more information") |
-| \`:rocket:[some-pipeline-lite]\` | This is a proper description with a \\| pipe | [:information_source:](https://github.com/some-org/some-repo/blob/master/.buildkite/pipeline/description/some-org/some-pipeline-lite.md "See more information") |
+<table>
+<thead>
+<tr>
+<th>Comment</th>
+<th>Description</th>
+<th>More info</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+\`\`\`
+:rocket:[a-pipeline]
+\`\`\`
+
+</td>
+<td>
+
+
+
+</td>
+<td>
+
+[:information_source:](https://example.com/does-templating-work?COMMITISH=c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffe&ORG=some-org&REPO=some-repo "See more information")
+
+</td>
+</tr>
+<tr>
+<td>
+
+\`\`\`
+:rocket:[some-pipeline]
+\`\`\`
+
+</td>
+<td>
+
+
+
+</td>
+<td>
+
+[:heavy_plus_sign:](https://github.com/some-org/some-repo/new/master?filename=.buildkite%2Fpipeline%2Fdescription%2Fsome-org%2Fsome-pipeline.md&value=%23+some-pipeline%0A%0A%5BDocument+some-pipeline%27s+RocketBot+options+here%5D "Add more information")
+
+</td>
+</tr>
+<tr>
+<td>
+
+\`\`\`
+:rocket:[some-pipeline-lite]
+\`\`\`
+
+</td>
+<td>
+
+This is a proper description with a \\| pipe
+
+</td>
+<td>
+
+[:information_source:](https://github.com/some-org/some-repo/blob/master/.buildkite/pipeline/description/some-org/some-pipeline-lite.md "See more information")
+
+</td>
+</tr>
+</tbody>
+</table>
 
 _Note: you can pass [custom environment variables](https://github.com/canva-public/rocketbot/blob/main/docs/guides/pass-in-variables.md) to some builds._
 

--- a/src/events/pr_opened.ts
+++ b/src/events/pr_opened.ts
@@ -76,7 +76,26 @@ export async function prOpened(
     .map(({ slug, description: desc }) => {
       // TODO: proper markdown sanitization
       const description = (desc?.trim() ?? '').trim().replace(/\|/g, '\\|');
-      return `| \`:rocket:[${slug}]\` | ${description} | ${links[slug]} |`;
+      // We need raw HTML tables to be able to insert a code block to enable Github's copy button
+      return `<tr>
+<td>
+
+\`\`\`
+:rocket:[${slug}]
+\`\`\`
+
+</td>
+<td>
+
+${description}
+
+</td>
+<td>
+
+${links[slug]}
+
+</td>
+</tr>`;
     })
     .join('\n');
   const commentData = await githubAddComment(
@@ -91,9 +110,18 @@ export async function prOpened(
 
 By commenting on this PR with: \`:rocket:[<pipeline>]\`, e.g.
 
-| Comment | Description | More info |
-| --- | --- | --- |
+<table>
+<thead>
+<tr>
+<th>Comment</th>
+<th>Description</th>
+<th>More info</th>
+</tr>
+</thead>
+<tbody>
 ${pipelineList}
+</tbody>
+</table>
 
 _Note: you can pass [custom environment variables](https://github.com/canva-public/rocketbot/blob/main/docs/guides/pass-in-variables.md) to some builds._
 


### PR DESCRIPTION
## Problem

Currently, the opening comment uses inline code spans to display the commands.

These require the user to select it precisely to copy.

Ideally, we can use the triple-click gesture to select an entire line instead of precisely targeting the line endpoints. But it does not work perfectly.


## Solution

Github recently introduced a [copy button for code blocks](https://twitter.com/github/status/1391867011832193030). Note that this does not include inline code spans, which the listing currently uses.

So the solution is to change the listing to use code blocks instead of code spans, and then we can easily one-click copy commands.

A side effect of this is that we are now forced to use raw HTML tables instead of Markdown tables in the template, because Markdown tables can only accept inline content, not block content.

Another side effect is that rows are now thicker. The comment body is collapsible anyway, so space is not a big concern.

## Testing

Jest tests have been updated.

I have no idea how to test the bot in a more real environment.