### PR TITLE
Add octokit retry plugin

### DIFF
--- a/docs/guides/install-and-configure.md
+++ b/docs/guides/install-and-configure.md
@@ -45,6 +45,7 @@ type Config = {
   ENABLE_DEBUG?: string; // defaults to "false"
   GITHUB_WEBHOOK_SECRET?: string; // A webhook secret to verify the webhook request against
   COLLAPSE_OLD_COMMENTS?: string; // defaults to "true"; collapses old RocketBot comments when adding/editing new ones
+  GITHUB_RETRY_FAILED_REQUESTS?: string; // defaults to "true"; automatically retry Github requests based on recommended status codes
 } & (
   | {
       // RocketBot uses a GitHub app. Recommended.

--- a/env.json.template
+++ b/env.json.template
@@ -8,6 +8,7 @@
         "GITHUB_TOKEN": "...",
         "BUILDKITE_TOKEN": "...",
         "BUILDKITE_ORG_NAME": "...",
-        "ENABLE_DEBUG": "true"
+        "ENABLE_DEBUG": "true",
+        "GITHUB_RETRY_FAILED_REQUESTS": "true"
     }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@octokit/auth-app": "^3.4.0",
     "@octokit/graphql": "^4.6.1",
+    "@octokit/plugin-retry": "^3.0.9",
     "@octokit/rest": "^18.5.3",
     "@octokit/webhooks-methods": "^1.0.0",
     "aws-lambda": "^1.0.6",

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ const BaseConfig = z.object({
   ENABLE_DEBUG: z.string().optional(),
   [GITHUB_WEBHOOK_SECRET_KEY]: z.string().optional(),
   COLLAPSE_OLD_COMMENTS: z.string().optional().default('true'),
+  GITHUB_RETRY_FAILED_REQUESTS: z.string().optional().default('true'),
 });
 
 export const Config = z.union([

--- a/template.yml
+++ b/template.yml
@@ -15,6 +15,7 @@ Globals:
         BUILDKITE_TOKEN: ~
         BUILDKITE_ORG_NAME: ~
         ENABLE_DEBUG: ~
+        GITHUB_RETRY_FAILED_REQUESTS: ~
 
 Resources:
   RocketBot:

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,6 +668,14 @@
     "@octokit/types" "^6.13.1"
     deprecation "^2.3.1"
 
+"@octokit/plugin-retry@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz#ae625cca1e42b0253049102acd71c1d5134788fe"
+  integrity sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    bottleneck "^2.15.3"
+
 "@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.5.tgz#72cc91edc870281ad583a42619256b380c600143"
@@ -1443,6 +1451,11 @@ before-after-hook@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
   integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
+
+bottleneck@^2.15.3:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
**Summary**: add [octokit/plugin-retry.js](https://github.com/octokit/plugin-retry.js)

**Problem**: every now and then github would have a blip and return an error (for example 502) when rocketbot try edit a comment. When this happens a retry from the user (making another comment) would solve the problem

**Solution**: add automatic retry to octokit, the default is 3 retries after 1 second each

**Note**: retry is disabled for most test so that nocks don't have to be updated with `.times()` everywhere where it's not testing the retry
