### PR TITLE
[Chore] Update action-zip provider name

### DIFF
--- a/.github/workflows/zip-release.yml
+++ b/.github/workflows/zip-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Create zip
-        uses: papeloto/action-zip@v1
+        uses: vimtor/action-zip@v1
         with:
           files: dist/index.js
           dest: release.zip


### PR DESCRIPTION
Action provider has changed names [SC-796].

`papeloto/action-zip` to `vimtor/action-zip`




